### PR TITLE
PKG-11365-lark-0.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,12 +19,10 @@ requirements:
   host:
     - pip
     - python
+    - setuptools
     - regex
   run:
     - python
-    - regex
-    - atomicwrites
-    # js2py omitted as it's not compatible with python >=3.12
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lark" %}
-{% set version = "1.2.2" %}
+{% set version = "0.12.0" %}
 
 
 package:
@@ -7,28 +7,28 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/lark-{{ version }}.tar.gz
-  sha256: ca807d0162cd16cef15a8feecb862d7319e7a09bdb13aef927968e45040fed80
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/lark-{{ version }}.tar.gz
+  sha256: 7da76fcfddadabbbbfd949bbae221efd33938451d90b1fefbbc423c3cccf48ef
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<38]
+  skip: True  # [py<36]
     
 requirements:
   host:
     - pip
     - python
-    - setuptools
-    - wheel
+    - regex
   run:
     - python
-  run_constrained:
-    - interegular >=0.3.1,<0.4.0
+    - regex
+    - atomicwrites
+    # js2py omitted as it's not compatible with python >=3.12
 
 test:
   source_files:
-  - tests
+    - tests
   imports:
     - lark
   commands:


### PR DESCRIPTION
lark 0.12.0

**Destination channel:** Defaults

### Links

- [PKG-11365](https://anaconda.atlassian.net/browse/PKG-11365)
- dev_url: https://github.com/lark-parser/lark/tree/0.12.0
- conda_forge: https://github.com/conda-forge/lark-feedstock
- pypi: https://pypi.org/project/lark/0.12.0/

### Explenation of changes

Downgrade to `0.12.0`. Check [PKG-11365](https://anaconda.atlassian.net/browse/PKG-11365) for dependency chain

[PKG-11365]: https://anaconda.atlassian.net/browse/PKG-11365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-11365]: https://anaconda.atlassian.net/browse/PKG-11365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ