### PR TITLE
lark 1.2.2 rebuild for python 3.14

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,11 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/lark-{{ version }}.tar.gz
   sha256: ca807d0162cd16cef15a8feecb862d7319e7a09bdb13aef927968e45040fed80
+  patches:                                                                    # [ py>=314]
+    - patches/0001-Wrap-functools.partial-in-staticmethod-to-add-compat.patch # [ py>=314]
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<38]
     

--- a/recipe/patches/0001-Wrap-functools.partial-in-staticmethod-to-add-compat.patch
+++ b/recipe/patches/0001-Wrap-functools.partial-in-staticmethod-to-add-compat.patch
@@ -1,0 +1,38 @@
+From 7303e8438caaafbd5935c749b1e41669ce719ed9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tom=C3=A1=C5=A1=20Hrn=C4=8Diar?= <thrnciar@redhat.com>
+Date: Wed, 6 Nov 2024 16:47:11 +0100
+Subject: [PATCH] Wrap functools.partial in staticmethod() to add compatibility
+ with Python 3.14
+
+Fixes: #1480
+---
+ tests/test_trees.py | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tests/test_trees.py b/tests/test_trees.py
+index 1f69869..07687ac 100644
+--- a/tests/test_trees.py
++++ b/tests/test_trees.py
+@@ -254,7 +254,7 @@ class TestTrees(TestCase):
+             ab_partialmethod = partialmethod(ab_for_partialmethod, 1)
+             set_union = set(["a"]).union
+             static_add = staticmethod(add)
+-            partial_reduce_mul = partial(reduce, mul)
++            partial_reduce_mul = staticmethod(partial(reduce, mul))
+ 
+             custom_callable = CustomCallable()
+ 
+@@ -355,8 +355,8 @@ class TestTrees(TestCase):
+ 
+         @v_args(inline=True)
+         class T(Transformer):
+-            a = functools.partial(test, "@", postfix="!")
+-            b = functools.partial(lambda s: s + "!")
++            a = staticmethod(functools.partial(test, "@", postfix="!"))
++            b = staticmethod(functools.partial(lambda s: s + "!"))
+ 
+         res = T().transform(tree)
+         assert res.children == ["@TEST1!", "test2!"]
+-- 
+2.51.0
+


### PR DESCRIPTION
lark 1.2.2 rebuild for python 3.14

**Destination channel:** defaults

### Links

- [PKG-16616](https://anaconda.atlassian.net/browse/PKG-16616) 
- Upstream repo: https://github.com/lark-parser/lark/tree/1.2.2
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- new patch cherry picked from upstream to fix a problem with the tests for python 3.14 builds. See https://github.com/lark-parser/lark/pull/1483 for the upstream PR.
- bump build number


[PKG-16616]: https://anaconda.atlassian.net/browse/PKG-16616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ